### PR TITLE
Listen for prequal:close event to close modal

### DIFF
--- a/sdk/src/main/res/raw/modal_template.html
+++ b/sdk/src/main/res/raw/modal_template.html
@@ -65,6 +65,7 @@
             var onCloseProductModal = function() {
                 window.location.href = "{{CANCEL_URL}}"
             }
+            affirm.events.on('prequal:close', onCloseProductModal);
             affirm.setAffirmConfig(elem, {onCloseModal: onCloseProductModal});
         });
         // END AFFIRM.JS EMBED CODE


### PR DESCRIPTION
The Javascript models that are used to display the educational modals have recently changed. This broke the integration with the modal and Android SDK since the modal change was not backwards-compatible. An event ("prequal:close") is emitted when the new modal is closed, and this commit listens for that event and calls the modal close callback.

JIRAs: [DROID-1016](https://jira.team.affirm.com/browse/DROID-1016), [DROID-1019](https://jira.team.affirm.com/browse/DROID-1019)

Tested using emulator:
![2019-01-03 10 43 49](https://user-images.githubusercontent.com/5918935/50655277-7e241f00-0f44-11e9-9424-a0cf1cf4c7da.gif)
